### PR TITLE
Dotnet-Outdated: Upgrade Newtonsoft.Json to 13.0.2

### DIFF
--- a/SampleOutdated.csproj
+++ b/SampleOutdated.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This bumps the following packages:
| Package | Old Version | New Version |
| - | - | - |
| Newtonsoft.Json | 13.0.1 | 13.0.2 |
