### PR TITLE
Neukeeper: Upgrade Serilog to 2.12.0

### DIFF
--- a/SampleOutdated.csproj
+++ b/SampleOutdated.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.7" />
   </ItemGroup>
 


### PR DESCRIPTION
This bumps the following packages:

| Package | Old Version | New Version |
| - | - | - |
| Serilog | 2.7.1 | 2.12.0 |
