### PR TITLE
Neukeeper: Upgrade Serilog to 3.0.1

### DIFF
--- a/SampleOutdated.csproj
+++ b/SampleOutdated.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="System.Text.Json" Version="6.0.5" />
   </ItemGroup>
 


### PR DESCRIPTION
This bumps the following packages:

| Package | Old Version | New Version |
| - | - | - |
| Serilog | 2.7.1 | 3.0.1 |
